### PR TITLE
fix: Correct ImportError for WaveScenario in strategy files

### DIFF
--- a/src/strategies/h4_strategy.py
+++ b/src/strategies/h4_strategy.py
@@ -4,7 +4,7 @@ from typing import List, Tuple
 import pandas as pd
 from src.data.bybit_client import BybitClient
 from src.elliott_wave_engine.engine import ElliottWaveEngine
-from src.analysis.wave_structure import WaveScenario
+from src.elliott_wave_engine.wave_structure import WaveScenario
 
 def h4_long_term_strategy(symbol: str, strict: bool = True) -> Tuple[List[WaveScenario], pd.DataFrame]:
     """

--- a/src/strategies/m15_strategy.py
+++ b/src/strategies/m15_strategy.py
@@ -4,7 +4,7 @@ from typing import List, Tuple
 import pandas as pd
 from src.data.bybit_client import BybitClient
 from src.elliott_wave_engine.engine import ElliottWaveEngine
-from src.analysis.wave_structure import WaveScenario
+from src.elliott_wave_engine.wave_structure import WaveScenario
 
 def m15_scalp_strategy(symbol: str, strict: bool = True) -> Tuple[List[WaveScenario], pd.DataFrame]:
     """

--- a/src/strategies/m3_strategy.py
+++ b/src/strategies/m3_strategy.py
@@ -4,7 +4,7 @@ from typing import List, Tuple
 import pandas as pd
 from src.data.bybit_client import BybitClient
 from src.elliott_wave_engine.engine import ElliottWaveEngine
-from src.analysis.wave_structure import WaveScenario
+from src.elliott_wave_engine.wave_structure import WaveScenario
 
 def m3_scalp_strategy(symbol: str, strict: bool = True) -> Tuple[List[WaveScenario], pd.DataFrame]:
     """

--- a/src/strategies/m5_strategy.py
+++ b/src/strategies/m5_strategy.py
@@ -4,7 +4,7 @@ from typing import List, Tuple
 import pandas as pd
 from src.data.bybit_client import BybitClient
 from src.elliott_wave_engine.engine import ElliottWaveEngine
-from src.analysis.wave_structure import WaveScenario
+from src.elliott_wave_engine.wave_structure import WaveScenario
 
 def m5_scalp_strategy(symbol: str, strict: bool = True) -> Tuple[List[WaveScenario], pd.DataFrame]:
     """


### PR DESCRIPTION
This commit fixes a critical `ImportError` that prevented the bot from starting.

The `WaveScenario` class was being imported from `src/analysis/wave_structure.py` in all four strategy files, but its correct location is `src/elliott_wave_engine/wave_structure.py`.

This change corrects the import path in:
- `src/strategies/h4_strategy.py`
- `src/strategies/m15_strategy.py`
- `src/strategies/m5_strategy.py`
- `src/strategies/m3_strategy.py`