### PR TITLE
fix: Add candle index to pivot data to resolve KeyError

### DIFF
--- a/src/elliott_wave_engine/indicators/pivots.py
+++ b/src/elliott_wave_engine/indicators/pivots.py
@@ -9,9 +9,9 @@ def find_pivots(df: pd.DataFrame, prominence: float = 1.0) -> List[Dict[str, Any
     low_peaks_indices, _ = find_peaks(-df['low'], prominence=prominence)
     pivots = []
     for i in high_peaks_indices:
-        pivots.append({"time": df.index[i], "price": df['high'][i], "type": "H"})
+        pivots.append({"time": df.index[i], "price": df['high'][i], "type": "H", "idx": i})
     for i in low_peaks_indices:
-        pivots.append({"time": df.index[i], "price": df['low'][i], "type": "L"})
+        pivots.append({"time": df.index[i], "price": df['low'][i], "type": "L", "idx": i})
     pivots.sort(key=lambda p: p['time'])
     if not pivots: return []
     cleaned_pivots = [pivots[0]]


### PR DESCRIPTION
This commit fixes a critical `KeyError: 'idx'` that caused the analysis engine to crash during runtime.

The error occurred because the pattern generator functions were trying to access an `idx` key from the pivot dictionaries, but this key was not being added when the pivots were created.

This change modifies the `find_pivots` function in `src/elliott_wave_engine/indicators/pivots.py` to include the candle index (`'idx': i`) in each pivot dictionary it generates. This ensures the data is correct at its source and resolves the downstream errors in the generators and the background scanner.