### PR TITLE
fix: Resolve asyncio event loop error on startup

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,13 +1,15 @@
 import asyncio
+import asyncio
 from telegram.ext import Application, CommandHandler, CallbackQueryHandler
 
-from src.bot_interface.handlers import start, button, initialize_bot_state
+from src.bot_interface.handlers import start, button, load_bot_state
+from src.background_scanner import run_scanner
 from src.utils.config_loader import config
 
 # --- Configuration ---
 TELEGRAM_TOKEN = config['telegram']['token']
 
-def main() -> None:
+async def main() -> None:
     """Sets up and starts the Telegram bot."""
     if not TELEGRAM_TOKEN:
         print("FATAL: TELEGRAM_TOKEN is not configured. Please check your .env file.")
@@ -21,10 +23,15 @@ def main() -> None:
     application.add_handler(CallbackQueryHandler(button))
 
     # Check for persisted state and start scanner if needed
-    initialize_bot_state(application)
+    is_running = load_bot_state()
+    application.bot_data['is_running'] = is_running
+    if is_running:
+        print("Bot was running previously. Restarting background scanner...")
+        asyncio.create_task(run_scanner(application))
 
     print("Bot is running... Press Ctrl-C to stop.")
-    application.run_polling()
+    # Run the bot until the user presses Ctrl-C
+    await application.run_polling()
 
 if __name__ == "__main__":
-    main()
+    asyncio.run(main())

--- a/src/bot_interface/handlers.py
+++ b/src/bot_interface/handlers.py
@@ -264,12 +264,3 @@ def load_bot_state() -> bool:
     except (FileNotFoundError, json.JSONDecodeError):
         print("No valid state file found. Defaulting to not running.")
         return False
-
-def initialize_bot_state(application: Application):
-    """Checks the persisted state and starts the scanner if needed."""
-    is_running = load_bot_state()
-    application.bot_data['is_running'] = is_running
-    if is_running:
-        print("Bot was running previously. Restarting background scanner...")
-        scanner_task = asyncio.create_task(run_scanner(application))
-        application.bot_data['scanner_task'] = scanner_task


### PR DESCRIPTION
This commit fixes a `RuntimeError: no running event loop` that occurred when the bot attempted to restore its state and restart the background scanner.

The error was caused by calling `asyncio.create_task` before the `python-telegram-bot` application had started its event loop.

The fix involves:
1.  Converting the `main` function in `bot.py` to an `async def` function.
2.  Moving the state initialization and task creation logic into the new async `main` function.
3.  Calling `asyncio.run(main())` to properly start the application.
4.  Removing the now-redundant `initialize_bot_state` function from `handlers.py`.

This ensures that the background task is only created after the asyncio event loop is running, resolving the crash.