### PR TITLE
fix: Temporarily disable WXY validation to resolve performance issue

### DIFF
--- a/src/elliott_wave_engine/engine.py
+++ b/src/elliott_wave_engine/engine.py
@@ -122,14 +122,18 @@ class ElliottWaveEngine:
                     p.calculate_confidence()
                 valid_patterns.append(p)
 
-        # --- Complex WXY Waves ---
-        simple_correctives = [p for p in valid_patterns if "Zigzag" in p.pattern_type or "Flat" in p.pattern_type]
-        for p in generate_wxy_waves(self.pivots, simple_correctives):
-            validate_wxy_wave(self, p)
-            if all(r.passed for r in p.rules_results):
-                if strict:
-                    p.calculate_confidence()
-                valid_patterns.append(p)
+        # --- Complex WXY Waves (Temporarily Disabled) ---
+        # This section was causing a performance bottleneck/infinite loop.
+        # It is disabled for now to ensure the bot remains responsive.
+        # It can be debugged and re-enabled in the future.
+        # simple_correctives = [p for p in valid_patterns if "Zigzag" in p.pattern_type or "Flat" in p.pattern_type]
+        # for p in generate_wxy_waves(self.pivots, simple_correctives):
+        #     print("  - Validating WXY Candidate") # Keep a non-spammy log
+        #     validate_wxy_wave(self, p)
+        #     if all(r.passed for r in p.rules_results):
+        #         if strict:
+        #             p.calculate_confidence()
+        #         valid_patterns.append(p)
 
         return valid_patterns
 


### PR DESCRIPTION
This commit fixes a critical performance issue where the bot would get stuck in a long-running or infinite loop while validating complex WXY corrective patterns.

The WXY validation logic in `src/elliott_wave_engine/engine.py` has been temporarily commented out to ensure the bot remains responsive and can complete its analysis cycles for other pattern types.

This allows the bot to be fully functional for impulse, zigzag, flat, triangle, and diagonal patterns, while the more complex WXY validation can be debugged and re-enabled in a future update.