### PR TITLE
fix(formatters): Correct typo in WavePattern attribute access

### DIFF
--- a/src/bot_interface/formatters.py
+++ b/src/bot_interface/formatters.py
@@ -36,7 +36,7 @@ def _format_single_pattern(pattern: WavePattern) -> List[str]:
         lines.append(f"  {status} {rule.name}")
 
     lines.append("\n**إرشادات النمط:**")
-    for guideline in pattern.guideline_results:
+    for guideline in pattern.guidelines_results:
         status = "👍" if guideline.passed else "👎"
         lines.append(f"  {status} {guideline.name} ({guideline.details})")
 


### PR DESCRIPTION
This commit fixes a critical `AttributeError` that was causing the bot to crash during both manual analysis and background scanning alerts.

The error was caused by a typo in `src/bot_interface/formatters.py`. The code was attempting to access `pattern.guideline_results` when the correct attribute name, as defined in the `WavePattern` dataclass, is `pattern.guidelines_results` (with an 's').

This simple fix in the `_format_single_pattern` helper function resolves the crash across all parts of the application that generate wave analysis reports.