### PR TITLE
fix(pivots): Add robust patch to recover incorrect DataFrame index

### DIFF
--- a/src/elliott_wave_engine/indicators/pivots.py
+++ b/src/elliott_wave_engine/indicators/pivots.py
@@ -3,9 +3,18 @@ from scipy.signal import find_peaks
 from typing import List, Dict, Any
 
 def find_pivots(df: pd.DataFrame, prominence: float = 1.0) -> List[Dict[str, Any]]:
-    # Defensive check to ensure the index is of the correct type.
+    # Robustness Patch: If the index is not a DatetimeIndex, attempt to fix it.
+    # This is a workaround for an upstream bug where the index is being reset.
     if not isinstance(df.index, pd.DatetimeIndex):
-        raise TypeError(f"DataFrame index in find_pivots must be a DatetimeIndex, but it is {type(df.index)}")
+        if 'timestamp' in df.columns:
+            # If the timestamp column exists, use it to rebuild the index.
+            df = df.set_index('timestamp')
+            if not isinstance(df.index, pd.DatetimeIndex):
+                 # If the column is not already datetime, convert it.
+                 df.index = pd.to_datetime(df.index)
+        else:
+            # If we can't fix it, raise an error with more context.
+            raise TypeError(f"DataFrame index is not a DatetimeIndex and 'timestamp' column not found.")
 
     if 'high' not in df.columns or 'low' not in df.columns:
         raise ValueError("Input DataFrame must contain 'high' and 'low' columns.")


### PR DESCRIPTION
This commit addresses a critical `AttributeError: 'int' object has no attribute 'strftime'` crash that was making the bot unusable.

The root cause was identified as the DataFrame passed to the `find_pivots` function having a `RangeIndex` instead of the expected `DatetimeIndex`. This patch implements a robust workaround directly in `find_pivots` to handle this data corruption.

The new logic checks if the index is a `DatetimeIndex`. If it is not, it attempts to find a 'timestamp' column in the DataFrame and rebuild the `DatetimeIndex` from it. This prevents the crash and allows the analysis to proceed.

While the root cause of the index being reset upstream still needs investigation, this patch ensures the bot remains stable and functional for the user.