### PR TITLE
refine: Further refine pivot detection and update date format

### DIFF
--- a/src/bot_interface/formatters.py
+++ b/src/bot_interface/formatters.py
@@ -23,8 +23,8 @@ def _format_single_pattern(pattern: WavePattern) -> List[str]:
     lines = [f"\n--- {pattern.pattern_type} ---"]
     lines.append(f"**الثقة:** {pattern.confidence_score:.1f}%")
 
-    header = f"`{'الموجة':<7}| {'نقطة البداية':<22} | {'نقطة النهاية':<22} | {'التغيير':<10}`"
-    separator = f"`-------+------------------------+------------------------+-----------`"
+    header = f"`{'الموجة':<7}| {'نقطة البداية':<18} | {'نقطة النهاية':<18} | {'التغيير':<10}`"
+    separator = f"`-------+--------------------+--------------------+-----------`"
     lines.append("\n" + header)
     lines.append(separator)
 
@@ -40,11 +40,11 @@ def _format_single_pattern(pattern: WavePattern) -> List[str]:
         if i + 1 >= len(pattern.points): break
         p_start, p_end = pattern.points[i], pattern.points[i+1]
 
-        # Use the new dynamic formatting function
         price_format = _get_dynamic_price_format(p_start.price)
 
-        start_date_str = p_start.time.strftime('%Y-%m-%d')
-        end_date_str = p_end.time.strftime('%Y-%m-%d')
+        # Format date as DD-Mon (e.g., 07-Apr)
+        start_date_str = p_start.time.strftime('%d-%b')
+        end_date_str = p_end.time.strftime('%d-%b')
 
         start_point_str = f"{start_date_str} ${p_start.price:{price_format}}"
         end_point_str = f"{end_date_str} ${p_end.price:{price_format}}"
@@ -52,7 +52,7 @@ def _format_single_pattern(pattern: WavePattern) -> List[str]:
         change = p_end.price - p_start.price
         change_pct = (change / p_start.price) * 100 if p_start.price != 0 else 0
         change_str = f"{change_pct:+.2f}%"
-        row = f"`{label:<7}| {start_point_str:<22} | {end_point_str:<22} | {change_str:<10}`"
+        row = f"`{label:<7}| {start_point_str:<18} | {end_point_str:<18} | {change_str:<10}`"
         lines.append(row)
 
     lines.append("\n**قواعد النمط:**")

--- a/src/elliott_wave_engine/core/engine.py
+++ b/src/elliott_wave_engine/core/engine.py
@@ -55,19 +55,20 @@ class ElliottWaveEngine:
             return find_pivots(self.data, prominence=prominence)
 
         # Multipliers for ATR. Higher values find more major pivots.
+        # Increased again based on user feedback that 5.0 was not enough for 4h.
         prominence_map = {
-            '4h':  mean_atr * 5.0,
-            '240': mean_atr * 5.0,
-            '1h':  mean_atr * 3.0,
-            '60':  mean_atr * 3.0,
-            '15m': mean_atr * 1.5,
-            '15':  mean_atr * 1.5,
-            '5m':  mean_atr * 1.0,
-            '5':   mean_atr * 1.0,
-            '3m':  mean_atr * 0.75,
-            '3':   mean_atr * 0.75,
+            '4h':  mean_atr * 8.0,
+            '240': mean_atr * 8.0,
+            '1h':  mean_atr * 5.0,
+            '60':  mean_atr * 5.0,
+            '15m': mean_atr * 2.5,
+            '15':  mean_atr * 2.5,
+            '5m':  mean_atr * 2.0,
+            '5':   mean_atr * 2.0,
+            '3m':  mean_atr * 1.5,
+            '3':   mean_atr * 1.5,
         }
-        prominence = prominence_map.get(str(self.timeframe), mean_atr * 2.0) # Default prominence
+        prominence = prominence_map.get(str(self.timeframe), mean_atr * 3.0) # Default prominence
         return find_pivots(self.data, prominence=prominence)
 
     def run_analysis(self, strict: bool = True) -> List[WaveScenario]:


### PR DESCRIPTION
This commit implements two refinements based on detailed user feedback to improve analysis quality and report formatting.

1.  **Adjust Pivot Prominence:** The ATR multipliers in the `prominence_map` in `elliott_wave_engine/core/engine.py` have been increased again. This is in response to a specific user example where the previous values were still not high enough to filter out minor pivots and identify the most significant market structures. This change applies to all timeframes to ensure consistent analysis.

2.  **Update Date Formatting:** The date format in analysis reports has been changed from `YYYY-MM-DD` to `DD-Mon` (e.g., `07-Apr`). This was a direct formatting request from the user to improve readability. The table layout in `bot_interface/formatters.py` has been adjusted to accommodate the new format.