### PR TITLE
Chore: Add --break-system-packages flag for pip

### DIFF
--- a/auto_bot.sh
+++ b/auto_bot.sh
@@ -45,7 +45,7 @@ while true; do
         echo "Update found. Pulling changes..."
         git pull origin main
         echo "Installing/updating dependencies..."
-        pip install -r requirements.txt
+        pip install -r requirements.txt --break-system-packages
     fi
 
     # 4. Start the bot if it's not running


### PR DESCRIPTION
Adds the --break-system-packages flag to the `pip install` command in `auto_bot.sh`.

This is necessary to ensure dependencies can be installed correctly on newer Linux distributions that have externally managed environment protection, as reported by the user.