### PR TITLE
Feat: Add staged notifications for analysis progress

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,5 @@ requests
 PyYAML
 setuptools
 pytest
+pytest-asyncio
 python-dotenv

--- a/src/analysis_manager.py
+++ b/src/analysis_manager.py
@@ -41,16 +41,26 @@ class AnalysisManager:
         ltf_type = scenarios[0].primary_pattern.pattern_type.lower()
         self.context['decision_path'].append(f"->OK:{ltf_type[:5]}")
 
+        # New explicit stage marker
+        self.context['decision_path'].append(f"STAGE_PASSED:{tf_str}")
+
         if htf_context:
             htf_type = htf_context['scenarios'][0].primary_pattern.pattern_type.lower()
+            match_found = False
             if "impulse" in htf_type and any(c in ltf_type for c in ["zigzag", "flat", "triangle"]):
                 self.context['decision_path'].append("->MATCH:HTF_Imp/LTF_Corr")
-                return True
+                match_found = True
             elif any(c in htf_type for c in ["zigzag", "flat", "triangle"]) and "impulse" in ltf_type:
                 self.context['decision_path'].append("->MATCH:HTF_Corr/LTF_Imp")
+                match_found = True
+
+            if match_found:
+                # New explicit stage marker for alignment
+                self.context['decision_path'].append(f"STAGE_PASSED:ALIGN_{tf_str}")
                 return True
-            self.context['decision_path'].append("->REJECT:NoAlign")
-            return False
+            else:
+                self.context['decision_path'].append("->REJECT:NoAlign")
+                return False
         return True
 
     def _generate_trade_setup(self) -> bool:
@@ -66,6 +76,7 @@ class AnalysisManager:
 
         self.context['final_trade_setup'] = trade_setup
         self.context['decision_path'].append("->OK:SetupGenerated")
+        self.context['decision_path'].append("STAGE_PASSED:SETUP_GENERATED")
         return True
 
     def _confirm_entry_conditions(self) -> None:

--- a/src/background_scanner.py
+++ b/src/background_scanner.py
@@ -10,6 +10,7 @@ from src.utils.config_loader import config
 from src.bot_interface.formatters import format_trade_alert
 from src.analysis_manager import AnalysisManager
 from src.trading import state_manager, trade_manager, trade_logger
+from src.trading.state_manager import load_notification_state, save_notification_state
 from src.data.bybit_client import BybitClient
 
 # --- Load constants from config ---
@@ -28,6 +29,56 @@ def find_new_setups_sync(symbol: str) -> List[Dict[str, Any]]:
         manager.context['first_seen_timestamp'] = datetime.datetime.now().isoformat()
         return [manager.context]
     return []
+
+async def handle_analysis_notifications(app: Application, user_id: int, context: Dict[str, Any]):
+    """
+    Analyzes the decision path of a setup and sends granular, step-by-step notifications.
+    This function will be responsible for the "chatty bot" feature.
+    """
+    # Logic to be implemented in the next step:
+    # 1. Check the latest notified stage for this symbol's opportunity from state.
+    # 2. Parse the context['decision_path'] to find the current, most advanced stage.
+    # 3. If the current stage is newer than the notified stage:
+    decision_path = context.get('decision_path', [])
+    symbol = context.get('symbol')
+
+    # Define the stages and their corresponding messages
+    stage_messages = {
+        "STAGE_PASSED:4h": f"📈 **فرصة محتملة | {symbol} | 4H**\nتم رصد نمط مبدئي على فريم الأربع ساعات. جاري البحث عن تأكيد...",
+        "STAGE_PASSED:ALIGN_1h": f"✅ **تأكيد مبدئي | {symbol} | 1H**\nتم العثور على توافق مع فريم الساعة. جاري تحليل فريم 15 دقيقة...",
+        "STAGE_PASSED:ALIGN_15m": f"✅ **تأكيد متقدم | {symbol} | 15M**\nتم العثور على توافق مع فريم 15 دقيقة. جاري فحص شروط الدخول...",
+        "STAGE_PASSED:SETUP_GENERATED": f"⏳ **تجهيز الصفقة | {symbol}**\nتم تحديد معلمات الصفقة بنجاح. في انتظار إشارة الدخول النهائية..."
+    }
+
+    latest_stage = None
+    # Iterate in reverse to find the most recent significant stage
+    for stage in reversed(decision_path):
+        if stage in stage_messages:
+            latest_stage = stage
+            break
+
+    if latest_stage:
+        # Define a unique key for this specific opportunity
+        # A good key combines symbol and the start time of the primary pattern
+        try:
+            start_time = context['4h_scenarios'][0].start_point.time
+            opportunity_key = f"{symbol}_{start_time}"
+        except (KeyError, IndexError):
+            opportunity_key = f"{symbol}_unknown" # Fallback key
+
+        notification_state = load_notification_state()
+        last_notified_stage = notification_state.get(opportunity_key)
+
+        if latest_stage != last_notified_stage:
+            message = stage_messages[latest_stage]
+            try:
+                await app.bot.send_message(chat_id=user_id, text=message, parse_mode='Markdown')
+                # If message is sent successfully, update the state
+                notification_state[opportunity_key] = latest_stage
+                save_notification_state(notification_state)
+            except Exception as e:
+                print(f"Error sending analysis notification for {symbol}: {e}")
+
 
 async def handle_trade_update(app: Application, user_id: int, event: Dict[str, Any], trade: Dict[str, Any]):
     """Handles events from the trade manager, sends alerts, updates state, and logs completed trades."""
@@ -175,6 +226,10 @@ async def run_scanner(app: Application):
                                              f"**النمط:** `{trade_setup.get('pattern_type')}`\n"
                                              f"**الحالة:** {context['decision_path'][-1]}")
                                 info_alerts_text.append(info_text)
+
+                        else:
+                            # This is a REJECTED setup, but we might want to notify about its progress
+                            await handle_analysis_notifications(app, user_id, context)
 
                     if info_alerts_text:
                         final_info_message = "⏳ **فرص جديدة للمراقبة** ⏳\n\n" + "\n\n---\n\n".join(info_alerts_text)

--- a/src/trading/state_manager.py
+++ b/src/trading/state_manager.py
@@ -102,3 +102,32 @@ def save_deferred_setups(setups: List[Dict[str, Any]]) -> bool:
     except (IOError, TypeError) as e:
         print(f"ERROR: Could not save deferred setups to {DEFERRED_SETUPS_FILE}: {e}")
         return False
+
+# --- Notification State Management ---
+
+NOTIFICATION_STATE_FILE = 'notification_state.json'
+
+def load_notification_state() -> Dict[str, str]:
+    """Loads the state of which notifications have been sent."""
+    import os
+    if not os.path.exists(NOTIFICATION_STATE_FILE):
+        return {}
+    try:
+        with open(NOTIFICATION_STATE_FILE, 'r') as f:
+            # handle empty file case
+            content = f.read()
+            if not content:
+                return {}
+            return json.loads(content)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
+
+def save_notification_state(state: Dict[str, str]) -> bool:
+    """Saves the notification state to a file."""
+    try:
+        with open(NOTIFICATION_STATE_FILE, 'w') as f:
+            json.dump(state, f, indent=4)
+        return True
+    except (IOError, TypeError) as e:
+        print(f"ERROR: Could not save notification state to {NOTIFICATION_STATE_FILE}: {e}")
+        return False

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,0 +1,102 @@
+import pytest
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from src.background_scanner import handle_analysis_notifications
+
+@pytest.fixture
+def mock_app():
+    """Fixture to create a mock application object with a mock bot."""
+    app = MagicMock()
+    app.bot = AsyncMock()
+    return app
+
+@pytest.mark.asyncio
+async def test_sends_notification_for_new_stage(mock_app):
+    """
+    Tests that a notification is sent when a new, more advanced stage is detected.
+    """
+    # GIVEN an analysis context with a new stage
+    mock_scenario = MagicMock()
+    mock_scenario.start_point.time = '2025-01-01'
+    context = {
+        'symbol': 'BTCUSDT',
+        'decision_path': ['P(4h)', '->OK:impul', 'STAGE_PASSED:4h'],
+        '4h_scenarios': [mock_scenario]
+    }
+    user_id = 12345
+
+    # AND the current notification state is empty
+    with patch('src.background_scanner.load_notification_state', return_value={}) as mock_load, \
+         patch('src.background_scanner.save_notification_state') as mock_save:
+
+        # WHEN we handle the notification
+        await handle_analysis_notifications(mock_app, user_id, context)
+
+        # THEN a message should be sent
+        mock_app.bot.send_message.assert_called_once()
+        sent_text = mock_app.bot.send_message.call_args[1]['text']
+        assert "فرصة محتملة | BTCUSDT | 4H" in sent_text
+
+        # AND the state should be updated and saved
+        mock_save.assert_called_once_with({'BTCUSDT_2025-01-01': 'STAGE_PASSED:4h'})
+
+@pytest.mark.asyncio
+async def test_does_not_send_notification_for_same_stage(mock_app):
+    """
+    Tests that a notification is NOT sent if the stage has already been notified.
+    """
+    # GIVEN an analysis context
+    mock_scenario = MagicMock()
+    mock_scenario.start_point.time = '2025-01-01'
+    context = {
+        'symbol': 'BTCUSDT',
+        'decision_path': ['P(4h)', '->OK:impul', 'STAGE_PASSED:4h'],
+        '4h_scenarios': [mock_scenario]
+    }
+    user_id = 12345
+
+    # AND the notification for this stage has already been sent
+    existing_state = {'BTCUSDT_2025-01-01': 'STAGE_PASSED:4h'}
+    with patch('src.background_scanner.load_notification_state', return_value=existing_state) as mock_load, \
+         patch('src.background_scanner.save_notification_state') as mock_save:
+
+        # WHEN we handle the notification
+        await handle_analysis_notifications(mock_app, user_id, context)
+
+        # THEN no message should be sent
+        mock_app.bot.send_message.assert_not_called()
+
+        # AND the state should not be saved again
+        mock_save.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_sends_notification_for_upgraded_stage(mock_app):
+    """
+    Tests that a notification is sent when an opportunity progresses to a new stage.
+    """
+    # GIVEN an analysis context with a more advanced stage
+    mock_scenario = MagicMock()
+    mock_scenario.start_point.time = '2025-01-01'
+    context = {
+        'symbol': 'BTCUSDT',
+        'decision_path': ['P(4h)', '->OK:impul', 'STAGE_PASSED:4h', 'P(1h)', '->MATCH', 'STAGE_PASSED:ALIGN_1h'],
+        '4h_scenarios': [mock_scenario]
+    }
+    user_id = 12345
+
+    # AND the previously notified stage was the 4h stage
+    existing_state = {'BTCUSDT_2025-01-01': 'STAGE_PASSED:4h'}
+    with patch('src.background_scanner.load_notification_state', return_value=existing_state) as mock_load, \
+         patch('src.background_scanner.save_notification_state') as mock_save:
+
+        # WHEN we handle the notification
+        await handle_analysis_notifications(mock_app, user_id, context)
+
+        # THEN a new message should be sent for the upgraded stage
+        mock_app.bot.send_message.assert_called_once()
+        sent_text = mock_app.bot.send_message.call_args[1]['text']
+        assert "تأكيد مبدئي | BTCUSDT | 1H" in sent_text
+
+        # AND the state should be updated and saved with the new stage
+        mock_save.assert_called_once_with({'BTCUSDT_2025-01-01': 'STAGE_PASSED:ALIGN_1h'})


### PR DESCRIPTION
Implements a "chatty bot" feature to provide users with step-by-step updates on the trade analysis process.

Key changes:
- `src/analysis_manager.py`: Enhanced the `decision_path` to include explicit, machine-readable markers for each successful analysis stage (e.g., `STAGE_PASSED:4h`).
- `src/trading/state_manager.py`: Added new functions (`load_notification_state`, `save_notification_state`) and a new state file (`notification_state.json`) to track sent notifications.
- `src/background_scanner.py`:
    - A new function `handle_analysis_notifications` was created.
    - This function parses the `decision_path` of a given opportunity.
    - It uses the new state management functions to check if an update for the current analysis stage has already been sent.
    - If the update is new, it sends a user-friendly, formatted message to Telegram.
    - This function is now called from the main scanner loop for any opportunity that is not yet accepted or deferred.
- `tests/test_notifications.py`: Added a new test file with comprehensive unit tests for the notification handler, mocking the Telegram API and state manager to verify the logic for sending new notifications, handling upgrades, and preventing duplicates.
- `requirements.txt`: Added `pytest-asyncio` to support testing of the new asynchronous notification handler.