### PR TITLE
Fix(scanner): Ensure all analysis results are returned for notification

### DIFF
--- a/src/background_scanner.py
+++ b/src/background_scanner.py
@@ -24,10 +24,16 @@ def find_new_setups_sync(symbol: str) -> List[Dict[str, Any]]:
     """Uses the AnalysisManager to perform a full hierarchical analysis for a single symbol."""
     manager = AnalysisManager(symbol)
     manager.run_hierarchical_analysis()
+
+    # For ACCEPT/DEFER, we add a timestamp.
     if manager.context.get("final_decision") in ["ACCEPT", "DEFER"]:
-        # Add a timestamp to the context when it's first found
         manager.context['first_seen_timestamp'] = datetime.datetime.now().isoformat()
+
+    # Return the context if any analysis was actually performed.
+    # The main loop will handle routing based on the final_decision.
+    if manager.context and manager.context.get("decision_path"):
         return [manager.context]
+
     return []
 
 async def handle_analysis_notifications(app: Application, user_id: int, context: Dict[str, Any]):


### PR DESCRIPTION
The `find_new_setups_sync` function was previously only returning analysis contexts if the final decision was 'ACCEPT' or 'DEFER'. This meant that any analysis that was still in progress or ultimately rejected was never passed to the main scanner loop.

This prevented the `handle_analysis_notifications` function from ever being called, which is the function responsible for sending the progressive, 'chatty' updates the user expects (e.g., 'Pattern found on 4h', 'Confirmed on 1h').

The logic is now changed to return the context for any analysis that has a `decision_path`, regardless of the `final_decision`. The main scanner loop already contains the correct routing to handle these different cases, so this change enables the existing, but previously unreachable, notification code.