### PR TITLE
fix(bot): Disable persistence for ConversationHandler

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -44,7 +44,7 @@ async def main() -> None:
             # We use per_user and per_chat persistence to make this more robust
             # across bot restarts if the user is in the middle of a conversation.
             name="add_symbol_conversation",
-            persistent=True,
+            persistent=False,
         )
         application.add_handler(add_symbol_conv)
 


### PR DESCRIPTION
The `add_symbol_conv` handler was configured with `persistent=True` but no persistence backend was configured for the `Application`. This caused the bot to crash on startup.

This commit changes the setting to `persistent=False` to resolve the error. The conversation is short-lived, so losing state on restart is an acceptable tradeoff for ensuring the bot can start correctly.