### PR TITLE
fix(scanner): Add missing import for load_config

### DIFF
--- a/src/background_scanner.py
+++ b/src/background_scanner.py
@@ -6,7 +6,7 @@ import os
 from telegram.ext import Application
 from typing import Dict, Any, List, Optional
 
-from src.utils.config_loader import config
+from src.utils.config_loader import config, load_config
 from src.bot_interface.formatters import format_trade_alert
 from src.analysis_manager import AnalysisManager
 from src.trading import state_manager, trade_manager, trade_logger


### PR DESCRIPTION
The `run_scanner` function calls `load_config()` to get the latest list of symbols to scan, but the import for this function was missing, leading to a `NameError` on startup.

This commit adds the import and resolves the crash loop.