### PR TITLE
Fix incorrect path for symbols_to_scan in config_manager

### DIFF
--- a/src/utils/config_manager.py
+++ b/src/utils/config_manager.py
@@ -6,9 +6,9 @@ CONFIG_FILE = "config.yaml"
 def get_symbols_from_config() -> List[str]:
     """Reads the list of symbols to scan from the config file."""
     yaml, config = _load_yaml_and_config()
-    if not config:
+    if not config or 'scanner' not in config:
         return []
-    return config.get('symbols_to_scan', [])
+    return config['scanner'].get('symbols_to_scan', [])
 
 def _load_yaml_and_config():
     """Loads the yaml object and config data."""
@@ -28,15 +28,19 @@ def add_symbol_to_config(symbol: str) -> bool:
     Returns True if the symbol was added, False if it already existed or failed.
     """
     yaml, config = _load_yaml_and_config()
-    if not config:
+    if not config or 'scanner' not in config:
         return False
 
-    symbols = config.get('symbols_to_scan', [])
+    # Ensure 'symbols_to_scan' exists in the scanner section
+    if 'symbols_to_scan' not in config['scanner'] or config['scanner']['symbols_to_scan'] is None:
+        config['scanner']['symbols_to_scan'] = []
+
+    symbols = config['scanner']['symbols_to_scan']
     if symbol in symbols:
         return False  # Symbol already exists
 
     symbols.append(symbol)
-    config['symbols_to_scan'] = symbols
+    # The list is modified in-place, so we just need to dump the config.
 
     with open(CONFIG_FILE, 'w') as f:
         yaml.dump(config, f)
@@ -50,15 +54,15 @@ def remove_symbol_from_config(symbol: str) -> bool:
     Returns True if the symbol was removed, False if it was not found or failed.
     """
     yaml, config = _load_yaml_and_config()
-    if not config:
+    if not config or 'scanner' not in config or 'symbols_to_scan' not in config['scanner']:
         return False
 
-    symbols = config.get('symbols_to_scan', [])
+    symbols = config['scanner']['symbols_to_scan']
     if symbol not in symbols:
         return False # Symbol not found
 
     symbols.remove(symbol)
-    config['symbols_to_scan'] = symbols
+    # The list is modified in-place, so we just need to dump the config.
 
     with open(CONFIG_FILE, 'w') as f:
         yaml.dump(config, f)


### PR DESCRIPTION
The functions in `src/utils/config_manager.py` were attempting to access the `symbols_to_scan` list from the top level of the `config.yaml` file. This is incorrect, as the list is nested under the `scanner` key.

This commit corrects the access path in `get_symbols_from_config`, `add_symbol_to_config`, and `remove_symbol_from_config` to correctly read from and write to `config['scanner']['symbols_to_scan']`.

This fixes the bug where adding or removing symbols from the watchlist via the bot's settings menu would fail silently, making the feature appear broken.