### PR TITLE
Fix UI handlers to use correct config path for watchlist

### DIFF
--- a/src/bot_interface/handlers.py
+++ b/src/bot_interface/handlers.py
@@ -48,8 +48,7 @@ async def show_settings_menu(update: Update, context: ContextTypes.DEFAULT_TYPE,
     if query:
         await query.answer()
 
-    config = load_config()
-    symbols_list = config.get('symbols_to_scan', [])
+    symbols_list = config_manager.get_symbols_from_config()
 
     if symbols_list:
         symbols_text = "\n".join([f"- `{symbol}`" for symbol in symbols_list])
@@ -104,8 +103,7 @@ async def add_symbol_receive(update: Update, context: ContextTypes.DEFAULT_TYPE)
     was_added = config_manager.add_symbol_to_config(new_symbol)
 
     # Re-generate the settings menu text to show the result
-    config = load_config()
-    symbols_list = config.get('symbols_to_scan', [])
+    symbols_list = config_manager.get_symbols_from_config()
     symbols_text = "\n".join([f"- `{symbol}`" for symbol in symbols_list]) if symbols_list else "لا توجد عملات."
 
     if was_added:


### PR DESCRIPTION
The `show_settings_menu` and `add_symbol_receive` functions in `src/bot_interface/handlers.py` were manually loading the config file and accessing the `symbols_to_scan` list using an incorrect, top-level path.

This was causing the UI to display an empty or stale watchlist, even after a symbol was successfully added to the config file by the backend `config_manager`.

This commit refactors these functions to use the centralized `config_manager.get_symbols_from_config()` function, which correctly reads the list from the nested `scanner.symbols_to_scan` path. This ensures the UI is always consistent with the actual configuration.