### PR TITLE
Refactor config loading to fix stale data issues

### DIFF
--- a/src/background_scanner.py
+++ b/src/background_scanner.py
@@ -6,19 +6,14 @@ import os
 from telegram.ext import Application
 from typing import Dict, Any, List, Optional
 
-from src.utils.config_loader import config, load_config
+from src.utils.config_loader import load_config
 from src.bot_interface.formatters import format_trade_alert
 from src.analysis_manager import AnalysisManager
 from src.trading import state_manager, trade_manager, trade_logger
 from src.trading.state_manager import load_notification_state, save_notification_state
 from src.data.bybit_client import BybitClient
 
-# --- Load constants from config ---
-SCANNER_CONFIG = config.get('scanner', {})
-SCAN_INTERVAL_SECONDS = SCANNER_CONFIG.get('interval_seconds', 900)
-TRADING_RULES = config.get('trading_rules', {})
-MAX_TRADES_PER_DAY = TRADING_RULES.get('max_trades_per_day', 3)
-MAX_OPPORTUNITY_AGE_HOURS = TRADING_RULES.get('max_opportunity_age_hours', 24)
+# --- Constants are now loaded inside the scanner loop to ensure they are fresh ---
 
 
 # --- Scoring for aggregated notifications ---
@@ -166,14 +161,14 @@ def get_today_trade_count() -> int:
         print(f"Error reading trade history: {e}")
         return 0
 
-def cleanup_expired_deferred_setups():
+def cleanup_expired_deferred_setups(max_age_hours: int):
     """Loads deferred setups and removes any that are older than the configured max age."""
     now = datetime.datetime.now()
     setups_to_keep = []
     for setup_obj in state_manager.load_deferred_setups():
         first_seen = datetime.datetime.fromisoformat(setup_obj['first_seen_timestamp'])
         age_hours = (now - first_seen).total_seconds() / 3600
-        if age_hours < MAX_OPPORTUNITY_AGE_HOURS:
+        if age_hours < max_age_hours:
             setups_to_keep.append(setup_obj)
         else:
             print(f"INFO: Expired deferred setup for {setup_obj['setup']['symbol']} removed.")
@@ -193,9 +188,16 @@ async def run_scanner(app: Application):
                 await asyncio.sleep(60)
                 continue
 
+            # --- Load fresh constants from config for this cycle ---
             scanner_config = current_config.get('scanner', {})
+            trading_rules = current_config.get('trading_rules', {})
+
             symbols_to_scan = scanner_config.get('symbols_to_scan', [])
             notify_on_no_setups = scanner_config.get('notify_on_no_setups', False)
+            scan_interval_seconds = scanner_config.get('interval_seconds', 900)
+
+            max_trades_per_day = trading_rules.get('max_trades_per_day', 3)
+            max_opportunity_age_hours = trading_rules.get('max_opportunity_age_hours', 24)
 
             print(f"\n[{datetime.datetime.now()}] --- Running new scan cycle for symbols: {symbols_to_scan} ---")
             user_id = app.bot_data.get('user_id')
@@ -205,12 +207,12 @@ async def run_scanner(app: Application):
                 continue
 
             # --- Part 1: Cleanup Expired Opportunities ---
-            cleanup_expired_deferred_setups()
+            cleanup_expired_deferred_setups(max_opportunity_age_hours)
 
             # --- Part 2: Find New Trade Setups ---
             todays_trades = get_today_trade_count()
-            if todays_trades >= MAX_TRADES_PER_DAY:
-                print(f"Daily trade limit of {MAX_TRADES_PER_DAY} reached. Skipping new trade search.")
+            if todays_trades >= max_trades_per_day:
+                print(f"Daily trade limit of {max_trades_per_day} reached. Skipping new trade search.")
             else:
                 # This block handles finding setups and sending notifications.
                 all_found_setups = []
@@ -277,8 +279,8 @@ async def run_scanner(app: Application):
             # --- Part 3: Monitor Existing Active Trades ---
             await monitor_active_trades(app, user_id)
 
-            print(f"--- Scan cycle complete. Waiting {SCAN_INTERVAL_SECONDS} seconds. ---")
-            await asyncio.sleep(SCAN_INTERVAL_SECONDS)
+            print(f"--- Scan cycle complete. Waiting {scan_interval_seconds} seconds. ---")
+            await asyncio.sleep(scan_interval_seconds)
 
         except asyncio.CancelledError:
             print("Background scanner stopped.")

--- a/src/utils/config_loader.py
+++ b/src/utils/config_loader.py
@@ -60,6 +60,5 @@ def load_config():
     logging.info("Configuration loaded successfully and securely.")
     return config
 
-# Create a single, globally accessible config instance
-# This will be imported by other modules in the application
-config = load_config()
+# The load_config() function should be called by each module that needs
+# configuration data to ensure the latest version is always used.


### PR DESCRIPTION
This commit addresses the root cause of persistent bugs in the notification and settings features by refactoring how configuration is loaded and accessed.

The core issue was a global `config` object in `config_loader.py` that was loaded only once at application startup. This caused modules to use a stale view of the configuration, leading to a disconnect between the settings on disk and the values used by the running processes.

Changes:
1.  **`src/utils/config_loader.py`:** Removed the global `config` object to enforce a pattern of loading fresh configuration data when needed.
2.  **`src/background_scanner.py`:** Refactored to load all configuration parameters (scan interval, symbols, trading rules) inside the main `while` loop. This ensures that any changes made to `config.yaml` are immediately reflected in the next scan cycle.
3.  **`src/bot_interface/handlers.py` & `src/utils/config_manager.py`:** (These were fixed previously but are part of the overall solution) Ensured that the UI and config management layers correctly read from and write to the nested `scanner.symbols_to_scan` path in the config file.

This comprehensive fix ensures that the bot's behavior is always consistent with the latest configuration on disk, resolving both the silent failure of the notification system and the broken settings menu.