### PR TITLE
feat: Add single instance lock to bot.py

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,6 +1,18 @@
 import asyncio
 import signal
+import fcntl
+import sys
 from telegram.ext import Application, CommandHandler, CallbackQueryHandler, ConversationHandler, MessageHandler, filters
+
+# --- Single Instance Lock ---
+# This ensures that only one instance of the bot can run at a time.
+try:
+    lock_file = open('/tmp/trading_bot.lock', 'w')
+    fcntl.lockf(lock_file, fcntl.LOCK_EX | fcntl.LOCK_NB)
+except IOError:
+    print("البوت شغال فعلاً! (Another instance is already running.)")
+    sys.exit(1)
+# ---
 
 from src.bot_interface.handlers import (
     start, button, load_bot_state,


### PR DESCRIPTION
Implements a file-based locking mechanism at the start of `bot.py` to prevent multiple instances of the bot from running simultaneously.

This is achieved using the `fcntl` module to create a lock file in `/tmp/`. If an instance of the bot is already running, subsequent instances will detect the lock and exit immediately with a message, preventing potential issues with multiple Telegram bot connections and processes.