### PR TITLE
Fix a TypeError in the Telegram bot's start command handler.

### DIFF
--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -53,8 +53,7 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     logger.info(f"User {user.first_name} started the bot.")
 
     await update.message.reply_html(
-        f"أهلاً بك يا {user.mention_html()}!",
-        quote=False
+        f"أهلاً بك يا {user.mention_html()}!"
     )
     await update.message.reply_text(
         get_start_message_text(),


### PR DESCRIPTION
- The `update.message.reply_html()` method was being called with an unexpected keyword argument `quote=False`, causing a crash when a user started the bot.
- This was likely due to a version mismatch in the `python-telegram-bot` library.
- Removed the problematic argument to resolve the error. The bot should now start correctly.