### PR TITLE
fix: Handle minute timeframes in data fetcher

### DIFF
--- a/main_bot.py
+++ b/main_bot.py
@@ -35,11 +35,13 @@ class ComprehensiveTradingBot:
         """
         okx_symbol = self.symbol.replace('/', '-')
         timeframe = self.config['trading']['INTERVAL']
-        # Convert to OKX API format (e.g., '1d' -> '1D', '4h' -> '4H')
+        # Convert to OKX API format (e.g., '1d' -> '1D', '4h' -> '4H', '30m' -> '30M')
         if 'd' in timeframe:
             api_timeframe = timeframe.replace('d', 'D')
         elif 'h' in timeframe:
             api_timeframe = timeframe.replace('h', 'H')
+        elif 'm' in timeframe:
+            api_timeframe = timeframe.replace('m', 'M')
         else:
             api_timeframe = timeframe
 


### PR DESCRIPTION
This commit fixes a critical runtime error that occurred during analysis for medium and short-term timeframes (e.g., 30m, 15m, 5m).

The root cause was that the `fetch_data` method in `main_bot.py` did not correctly convert minute-based timeframes (like '30m') to the format required by the OKX API (e.g., '30M'). This caused the data fetching to fail, leading to a `ConnectionError` that was caught by the main exception handler, resulting in a generic failure message to the user.

The fix adds a condition to correctly capitalize the 'm' for minute-based timeframes, ensuring the API calls are successful.