### PR TITLE
fix: Update pandas-ta version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ plotly>=5.17.0
 aiohttp>=3.8.0
 asyncio-throttle>=1.0.2
 pytest>=7.4.0
-pandas-ta==0.3.14b0
+pandas-ta==0.4.67b0


### PR DESCRIPTION
This commit fixes a critical dependency issue by updating the version of `pandas-ta` in `requirements.txt` to `0.4.67b0`. The previous version (`0.3.14b0`) was incompatible with the latest version of `numpy`, causing an `ImportError` that prevented the application from starting. This change ensures a stable and working environment for the user.